### PR TITLE
Upload coverage report to codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
         run: make setup-test
       - name: Run tests
         run: make ci-test
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
 
   package:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,25 @@
 sipmessage
 ==========
 
+.. image:: https://img.shields.io/pypi/l/sipmessage.svg
+   :target: https://pypi.python.org/pypi/sipmessage
+   :alt: License
+
+.. image:: https://img.shields.io/pypi/v/sipmessage.svg
+   :target: https://pypi.python.org/pypi/sipmessage
+   :alt: Version
+
+.. image:: https://github.com/spacinov/sipmessage/workflows/tests/badge.svg
+   :target: https://github.com/spacinov/sipmessage/actions
+   :alt: Tests
+
+.. image:: https://img.shields.io/codecov/c/github/spacinov/sipmessage.svg
+   :target: https://codecov.io/gh/spacinov/sipmessage
+   :alt: Coverage
+
+.. image:: https://readthedocs.org/projects/sipmessage/badge/?version=latest
+   :target: https://sipmessage.readthedocs.io/
+   :alt: Documentation
 
 The ``sipmessage`` project provides a set of Python helpers and structures
 for parsing SIP messages.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,14 @@ sipmessage
    :target: https://pypi.python.org/pypi/sipmessage
    :alt: Version
 
+.. image:: https://github.com/spacinov/sipmessage/workflows/tests/badge.svg
+   :target: https://github.com/spacinov/sipmessage/actions
+   :alt: Tests
+
+.. image:: https://img.shields.io/codecov/c/github/spacinov/sipmessage.svg
+   :target: https://codecov.io/gh/spacinov/sipmessage
+   :alt: Coverage
+
 The ``sipmessage`` project provides a set of Python helpers and structures
 for parsing SIP messages.
 


### PR DESCRIPTION
Report code coverage to codecov, and display the corresponding badges in the README and the documentation.