### PR TITLE
Use `abnf` package to parse `Address`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "sipmessage"
 version = "0.2.2"
 
 # Dependencies
-dependencies = []
+dependencies = ["abnf"]
 requires-python = ">= 3.10"
 
 # Development

--- a/src/sipmessage/rfc3261.py
+++ b/src/sipmessage/rfc3261.py
@@ -1,0 +1,55 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+"""
+Collected rules from RFC 3261.
+https://datatracker.ietf.org/doc/html/rfc3261
+"""
+
+from abnf.grammars import rfc3986
+from abnf.grammars.misc import load_grammar_rules
+from abnf.parser import Rule as _Rule
+
+
+@load_grammar_rules(
+    [
+        ("absolute-URI", rfc3986.Rule("absolute-URI")),
+        ("host", rfc3986.Rule("host")),
+    ]
+)
+class Rule(_Rule):
+    """Rules from RFC 3261."""
+
+    grammar = [
+        "alphanum           =  ALPHA / DIGIT",
+        "LWS                =  [*WSP CRLF] 1*WSP ; linear whitespace",
+        "SWS                =  [LWS] ; sep whitespace",
+        "UTF8-NONASCII      =  %xC0-DF 1UTF8-CONT\
+                               / %xE0-EF 2UTF8-CONT\
+                               / %xF0-F7 3UTF8-CONT\
+                               / %xF8-Fb 4UTF8-CONT\
+                               / %xFC-FD 5UTF8-CONT",
+        "UTF8-CONT          =  %x80-BF",
+        'EQUAL              =  SWS "=" SWS ; equal',
+        'RAQUOT             =  ">" SWS ; right angle quote',
+        'LAQUOT             =  SWS "<"; left angle quote',
+        'SEMI               =  SWS ";" SWS ; semicolon',
+        'token              =  1*(alphanum / "-" / "." / "!" / "%" / "*"\
+                               / "_" / "+" / "`" / "\'" / "~" )',
+        "quoted-string      =  SWS DQUOTE *(qdtext / quoted-pair ) DQUOTE",
+        "qdtext             =  LWS / %x21 / %x23-5B / %x5D-7E\
+                               / UTF8-NONASCII",
+        'quoted-pair        =  "\\" (%x00-09 / %x0B-0C / %x0E-7F)',
+        "generic-param      =  token [ EQUAL gen-value ]",
+        "gen-value          =  token / host / quoted-string",
+        "contact-param      =  (name-addr / addr-spec) *(SEMI contact-params)",
+        "name-addr          =  [ display-name ] LAQUOT addr-spec RAQUOT",
+        # Not according to RFC, but good enough.
+        "addr-spec          =  absolute-URI",
+        "display-name       =  *(token LWS) / quoted-string",
+        # Not according to RFC, but good enough.
+        "contact-params     =  contact-extension",
+        "contact-extension  =  generic-param",
+    ]

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -17,7 +17,7 @@ class AddressTest(unittest.TestCase):
     def test_invalid_uri(self) -> None:
         with self.assertRaises(ValueError) as cm:
             Address.parse("atlanta.com")
-        self.assertEqual(str(cm.exception), "URI scheme must be 'sip' or 'sips'")
+        self.assertEqual(str(cm.exception), "Not a valid address")
 
     def test_no_brackets(self) -> None:
         contact = Address.parse("sip:+12125551212@phone2net.com;tag=887s")
@@ -26,23 +26,37 @@ class AddressTest(unittest.TestCase):
         self.assertEqual(contact.parameters, {"tag": "887s"})
         self.assertEqual(str(contact), "<sip:+12125551212@phone2net.com>;tag=887s")
 
-    def test_no_quotes(self) -> None:
-        contact = Address.parse("Anonymous <sip:c8oqz84zk7z@privacy.org>;tag=hyh8")
-        self.assertEqual(contact.name, "Anonymous")
+    def test_display_name_no_quotes(self) -> None:
+        contact = Address.parse(
+            "Anonymous  User\t! <sip:c8oqz84zk7z@privacy.org>;tag=hyh8"
+        )
+        self.assertEqual(contact.name, "Anonymous User !")
         self.assertEqual(str(contact.uri), "sip:c8oqz84zk7z@privacy.org")
         self.assertEqual(contact.parameters, {"tag": "hyh8"})
         self.assertEqual(
-            str(contact), '"Anonymous" <sip:c8oqz84zk7z@privacy.org>;tag=hyh8'
+            str(contact), '"Anonymous User !" <sip:c8oqz84zk7z@privacy.org>;tag=hyh8'
+        )
+
+    def test_display_name_with_quotes(self) -> None:
+        contact = Address.parse('"Bob" <sips:bob@biloxi.com> ;tag=a48s')
+        self.assertEqual(contact.name, "Bob")
+        self.assertEqual(str(contact.uri), "sips:bob@biloxi.com")
+        self.assertEqual(contact.parameters, {"tag": "a48s"})
+        self.assertEqual(str(contact), '"Bob" <sips:bob@biloxi.com>;tag=a48s')
+
+    def test_display_name_with_quotes_escape(self) -> None:
+        contact = Address.parse(
+            '"Bob \\"foo\\" \\\\backslashes \\\\\\\\ <bar>" <sips:bob@biloxi.com> ;tag=a48s'
+        )
+        self.assertEqual(contact.name, 'Bob "foo" \\backslashes \\\\ <bar>')
+        self.assertEqual(str(contact.uri), "sips:bob@biloxi.com")
+        self.assertEqual(contact.parameters, {"tag": "a48s"})
+        self.assertEqual(
+            str(contact),
+            '"Bob \\"foo\\" \\\\backslashes \\\\\\\\ <bar>" <sips:bob@biloxi.com>;tag=a48s',
         )
 
     def test_with_parameter_without_value(self) -> None:
         contact = Address.parse("<sip:1.2.3.4;lr>")
         self.assertEqual(contact.name, "")
         self.assertEqual(str(contact.uri), "sip:1.2.3.4;lr")
-
-    def test_with_quotes(self) -> None:
-        contact = Address.parse('"Bob" <sips:bob@biloxi.com> ;tag=a48s')
-        self.assertEqual(contact.name, "Bob")
-        self.assertEqual(str(contact.uri), "sips:bob@biloxi.com")
-        self.assertEqual(contact.parameters, {"tag": "a48s"})
-        self.assertEqual(str(contact), '"Bob" <sips:bob@biloxi.com>;tag=a48s')


### PR DESCRIPTION
Regular expressions are not sufficient to correctly parse quoted display names, so use the `abnf` package and import the grammar from RFC 3261.