### PR TITLE
Use grammar from RFC 3261 to parse URI

### DIFF
--- a/src/sipmessage/address.py
+++ b/src/sipmessage/address.py
@@ -6,17 +6,17 @@
 import dataclasses
 import re
 
+from . import grammar
 from .parameters import Parameters
 from .uri import URI
 
-TOKEN_LWS = r"[a-zA-Z0-9\-.!%*_+`'~ ]*"
-QUOTED_STRING = '"(?:[^"]|\\")*"'
+TOKEN_LWS = grammar.cset(grammar.C_TOKEN + " ")
 
 ADDRESS_PATTERNS = [
     # name-addr *(SEMI contact-params)
     re.compile(
         # display-name
-        "^(?P<name>" + TOKEN_LWS + "|" + QUOTED_STRING + ")"
+        f"^(?P<name>{TOKEN_LWS}*|{grammar.QUOTED_STRING})"
         # LAQUOT addr-spec RAQUOT
         "[ ]*"
         "<(?P<uri>[^>]+)>"

--- a/src/sipmessage/grammar.py
+++ b/src/sipmessage/grammar.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+import string
+
+
+def cset(chars: str) -> str:
+    """
+    Transform a collection of characters into a regular expression
+    character set.
+    """
+    return "[" + chars.replace("-", "\\-").replace("[", "\\[").replace("]", "\\]") + "]"
+
+
+# Character collections.
+C_ALPHA = string.ascii_letters
+C_ALPHANUM = string.ascii_letters + string.digits
+C_MARK = "-_.!~*/'()"
+C_TOKEN = C_ALPHANUM + "-.!%*_+`'~"
+C_UNRESERVED = C_ALPHANUM + C_MARK
+C_PASSWORD_SAFE = C_UNRESERVED + "&=+$,"
+C_USER_SAFE = C_UNRESERVED + "&=+$,;?/"
+C_URI_PARAM_SAFE = C_UNRESERVED + "[]/:&+$"
+
+# Regular expression fragments.
+ALPHA = cset(C_ALPHA)
+ALPHANUM = cset(C_ALPHANUM)
+HEXDIG = cset(string.hexdigits)
+ESCAPED = f"%{HEXDIG}{{2}}"
+QUOTED_STRING = '"(?:[^"]|\\")*"'
+
+HEXSEQ = f"{HEXDIG}{{1,4}}(?::{HEXDIG}{{1,4}})*"
+HEXPART = f"(?:{HEXSEQ}|{HEXSEQ}::(?:{HEXSEQ})?|::(?:{HEXSEQ})?)"
+IPV4ADDRESS = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+IPV6ADDRESS = f"{HEXPART}(?::{IPV4ADDRESS})?"
+IPV6REFERENCE = f"\\[{IPV6ADDRESS}\\]"
+
+DOMAINLABEL = f"{ALPHANUM}+([\\-]+{ALPHANUM}+)*"
+TOPLABEL = f"{ALPHA}+([\\-]+{ALPHANUM}+)*"
+HOSTNAME = f"(?:{DOMAINLABEL}\\.)*{TOPLABEL}[\\.]?"
+
+HOST = f"(?:{HOSTNAME}|{IPV4ADDRESS}|{IPV6REFERENCE})"
+USER = f"(?:{cset(C_USER_SAFE)}|{ESCAPED})+"
+PASSWORD = f"(?:{cset(C_PASSWORD_SAFE)}|{ESCAPED})+"
+PORT = "\\d+"
+
+URI_PARAMCHAR = f"(?:{cset(C_URI_PARAM_SAFE)}|{ESCAPED})"
+URI_GENERIC_PARAM = f"{URI_PARAMCHAR}+(?:={URI_PARAMCHAR}+)?"

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -17,7 +17,7 @@ class AddressTest(unittest.TestCase):
     def test_invalid_uri(self) -> None:
         with self.assertRaises(ValueError) as cm:
             Address.parse("atlanta.com")
-        self.assertEqual(str(cm.exception), "URI scheme must be 'sip' or 'sips'")
+        self.assertEqual(str(cm.exception), "Invalid URI")
 
     def test_no_brackets(self) -> None:
         contact = Address.parse("sip:+12125551212@phone2net.com;tag=887s")
@@ -67,3 +67,20 @@ class AddressTest(unittest.TestCase):
         contact = Address.parse("<sip:1.2.3.4;lr>")
         self.assertEqual(contact.name, "")
         self.assertEqual(str(contact.uri), "sip:1.2.3.4;lr")
+
+    def test_rfc4475_wide_range_of_valid_characters(self) -> None:
+        contact = Address.parse(
+            '"BEL:\x07 NUL:\x00 DEL:\x7f" '
+            "<sip:1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*@example.com>"
+        )
+        self.assertEqual(contact.name, "BEL:\x07 NUL:\x00 DEL:\x7f")
+        self.assertEqual(
+            str(contact.uri),
+            "sip:1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*@example.com",
+        )
+        self.assertEqual(contact.parameters, {})
+        self.assertEqual(
+            str(contact),
+            '"BEL:\x07 NUL:\x00 DEL:\x7f" '
+            "<sip:1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*@example.com>",
+        )

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -13,27 +13,28 @@ class URITest(unittest.TestCase):
         # No port.
         with self.assertRaises(ValueError) as cm:
             URI.parse("sip:atlanta.com:")
-        self.assertEqual(str(cm.exception), "URI port must be an integer")
+        self.assertEqual(str(cm.exception), "Invalid URI")
 
         # Invalid port.
         with self.assertRaises(ValueError) as cm:
             URI.parse("sip:atlanta.com:bob")
-        self.assertEqual(str(cm.exception), "URI port must be an integer")
+        self.assertEqual(str(cm.exception), "Invalid URI")
 
     def test_invalid_scheme(self) -> None:
         # No scheme.
         with self.assertRaises(ValueError) as cm:
             URI.parse("atlanta.com")
-        self.assertEqual(str(cm.exception), "URI scheme must be 'sip' or 'sips'")
+        self.assertEqual(str(cm.exception), "Invalid URI")
 
         # Invalid scheme.
         with self.assertRaises(ValueError) as cm:
             URI.parse("bogus:atlanta.com")
-        self.assertEqual(str(cm.exception), "URI scheme must be 'sip' or 'sips'")
+        self.assertEqual(str(cm.exception), "Invalid URI")
 
     def test_host(self) -> None:
         uri = URI.parse("sip:atlanta.com")
 
+        self.assertEqual(uri.scheme, "sip")
         self.assertEqual(uri.host, "atlanta.com")
         self.assertEqual(uri.port, None)
         self.assertEqual(uri.user, None)
@@ -46,6 +47,7 @@ class URITest(unittest.TestCase):
     def test_host_and_parameter_without_value(self) -> None:
         uri = URI.parse("sip:1.2.3.4;lr")
 
+        self.assertEqual(uri.scheme, "sip")
         self.assertEqual(uri.host, "1.2.3.4")
         self.assertEqual(uri.port, None)
         self.assertEqual(uri.user, None)
@@ -58,9 +60,10 @@ class URITest(unittest.TestCase):
         self.assertEqual(uri.global_phone_number, None)
         self.assertEqual(str(uri), "sip:1.2.3.4;lr")
 
-    def test_user_and_host(self) -> None:
+    def test_user(self) -> None:
         uri = URI.parse("sip:alice@atlanta.com")
 
+        self.assertEqual(uri.scheme, "sip")
         self.assertEqual(uri.host, "atlanta.com")
         self.assertEqual(uri.port, None)
         self.assertEqual(uri.user, "alice")
@@ -70,9 +73,35 @@ class URITest(unittest.TestCase):
         self.assertEqual(uri.global_phone_number, None)
         self.assertEqual(str(uri), "sip:alice@atlanta.com")
 
-    def test_user_and_host_and_parameters(self) -> None:
+    def test_user_escaped(self) -> None:
+        uri = URI.parse("sip:sips%3Auser%40example.com@example.net")
+
+        self.assertEqual(uri.scheme, "sip")
+        self.assertEqual(uri.host, "example.net")
+        self.assertEqual(uri.port, None)
+        self.assertEqual(uri.user, "sips:user@example.com")
+        self.assertEqual(uri.password, None)
+        self.assertEqual(uri.parameters, {})
+
+        self.assertEqual(str(uri), "sip:sips%3Auser%40example.com@example.net")
+
+    def test_user_question_mark(self) -> None:
+        uri = URI.parse("sip:alice?@atlanta.com")
+
+        self.assertEqual(uri.scheme, "sip")
+        self.assertEqual(uri.host, "atlanta.com")
+        self.assertEqual(uri.port, None)
+        self.assertEqual(uri.user, "alice?")
+        self.assertEqual(uri.password, None)
+        self.assertEqual(uri.parameters, {})
+
+        self.assertEqual(uri.global_phone_number, None)
+        self.assertEqual(str(uri), "sip:alice?@atlanta.com")
+
+    def test_user_and_parameters(self) -> None:
         uri = URI.parse("sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15")
 
+        self.assertEqual(uri.scheme, "sip")
         self.assertEqual(uri.host, "atlanta.com")
         self.assertEqual(uri.port, None)
         self.assertEqual(uri.user, "alice")
@@ -89,8 +118,9 @@ class URITest(unittest.TestCase):
         self.assertEqual(str(uri), "sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15")
 
     def test_phone_identity(self) -> None:
-        uri = URI.parse("sip:+123456789@1.2.3.4")
+        uri = URI.parse("sips:+123456789@1.2.3.4")
 
+        self.assertEqual(uri.scheme, "sips")
         self.assertEqual(uri.host, "1.2.3.4")
         self.assertEqual(uri.port, None)
         self.assertEqual(uri.user, "+123456789")
@@ -98,11 +128,12 @@ class URITest(unittest.TestCase):
         self.assertEqual(uri.parameters, {})
 
         self.assertEqual(uri.global_phone_number, "+123456789")
-        self.assertEqual(str(uri), "sip:+123456789@1.2.3.4")
+        self.assertEqual(str(uri), "sips:+123456789@1.2.3.4")
 
     def test_full(self) -> None:
         uri = URI.parse("sip:alice:secret@atlanta.com:5060;maddr=239.255.255.1;ttl=15")
 
+        self.assertEqual(uri.scheme, "sip")
         self.assertEqual(uri.host, "atlanta.com")
         self.assertEqual(uri.port, 5060)
         self.assertEqual(uri.user, "alice")
@@ -118,4 +149,42 @@ class URITest(unittest.TestCase):
         self.assertEqual(uri.global_phone_number, None)
         self.assertEqual(
             str(uri), "sip:alice:secret@atlanta.com:5060;maddr=239.255.255.1;ttl=15"
+        )
+
+    def test_password(self) -> None:
+        uri = URI.parse("sip:alice:secret@atlanta.com")
+
+        self.assertEqual(uri.scheme, "sip")
+        self.assertEqual(uri.host, "atlanta.com")
+        self.assertEqual(uri.port, None)
+        self.assertEqual(uri.user, "alice")
+        self.assertEqual(uri.password, "secret")
+        self.assertEqual(uri.parameters, {})
+
+        self.assertEqual(str(uri), "sip:alice:secret@atlanta.com")
+
+    def test_password_escaped(self) -> None:
+        uri = URI.parse("sip:alice:sips%3Auser%40example.com@atlanta.com")
+
+        self.assertEqual(uri.scheme, "sip")
+        self.assertEqual(uri.host, "atlanta.com")
+        self.assertEqual(uri.port, None)
+        self.assertEqual(uri.user, "alice")
+        self.assertEqual(uri.password, "sips:user@example.com")
+        self.assertEqual(uri.parameters, {})
+
+        self.assertEqual(str(uri), "sip:alice:sips%3Auser%40example.com@atlanta.com")
+
+    def test_rfc4475_torture(self) -> None:
+        uri = URI.parse(
+            "sip:1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*:&it+has=1,weird!*pas$wo~d_too.(doesn't-it)@example.com"
+        )
+        self.assertEqual(uri.host, "example.com")
+        self.assertEqual(uri.port, None)
+        self.assertEqual(uri.user, "1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*")
+        self.assertEqual(uri.password, "&it+has=1,weird!*pas$wo~d_too.(doesn't-it)")
+        self.assertEqual(uri.parameters, {})
+        self.assertEqual(
+            str(uri),
+            "sip:1_unusual.URI~(to-be!sure)&isn't+it$/crazy?,/;;*:&it+has=1,weird!*pas$wo~d_too.(doesn't-it)@example.com",
         )


### PR DESCRIPTION
We can now support escaped `user` or `password`.