### PR TITLE
Improve `Parameters` and `Via` header parsing

### DIFF
--- a/src/sipmessage/address.py
+++ b/src/sipmessage/address.py
@@ -21,8 +21,8 @@ ADDRESS_PATTERNS = [
         "[ ]*"
         "<(?P<uri>[^>]+)>"
         # *(SEMI contact-params)
-        "[ ]*"
-        r"(?:;(?P<parameters>[^\?]*))?"
+        f"(?P<parameters>(?:{grammar.SEMI}{grammar.GENERIC_PARAM})*)"
+        "$"
     ),
     # addr-spec *(SEMI contact-params)
     re.compile(
@@ -31,8 +31,8 @@ ADDRESS_PATTERNS = [
         # addr-spec
         "(?P<uri>[^ ;]+)"
         # *(SEMI contact-params)
-        "[ ]*"
-        r"(?:;(?P<parameters>[^\?]*))?"
+        f"(?P<parameters>(?:{grammar.SEMI}{grammar.GENERIC_PARAM})*)"
+        "$"
     ),
 ]
 
@@ -71,8 +71,7 @@ class Address:
         If parsing fails, a :class:`ValueError` is raised.
         """
 
-        # All linear white space, including folding, has the same semantics as SP.
-        value = re.sub(r"\s+", " ", value).strip()
+        value = grammar.simplify_whitespace(value)
 
         for pattern in ADDRESS_PATTERNS:
             m = pattern.match(value)
@@ -83,7 +82,7 @@ class Address:
                     parameters=Parameters.parse(m.group("parameters")),
                 )
         else:
-            raise ValueError("Not a valid address")
+            raise ValueError("Address is not valid")
 
     def __str__(self) -> str:
         s = ""

--- a/src/sipmessage/grammar.py
+++ b/src/sipmessage/grammar.py
@@ -3,6 +3,7 @@
 # Distributed under the 2-clause BSD license
 #
 
+import re
 import string
 
 
@@ -12,6 +13,16 @@ def cset(chars: str) -> str:
     character set.
     """
     return "[" + chars.replace("-", "\\-").replace("[", "\\[").replace("]", "\\]") + "]"
+
+
+def simplify_whitespace(value: str) -> str:
+    """
+    Replace any whitespace by a single space.
+
+    According to RFC 3261, all linear white space, including folding,
+    has the same semantics as SP.
+    """
+    return re.sub(r"\s+", " ", value).strip()
 
 
 # Character collections.
@@ -29,7 +40,12 @@ ALPHA = cset(C_ALPHA)
 ALPHANUM = cset(C_ALPHANUM)
 HEXDIG = cset(string.hexdigits)
 ESCAPED = f"%{HEXDIG}{{2}}"
+TOKEN = f"{cset(C_TOKEN)}+"
 QUOTED_STRING = '"(?:[^"]|\\")*"'
+
+EQUAL = "[ ]*=[ ]*"
+SEMI = "[ ]*;[ ]*"
+SLASH = "[ ]*/[ ]*"
 
 HEXSEQ = f"{HEXDIG}{{1,4}}(?::{HEXDIG}{{1,4}})*"
 HEXPART = f"(?:{HEXSEQ}|{HEXSEQ}::(?:{HEXSEQ})?|::(?:{HEXSEQ})?)"
@@ -47,4 +63,7 @@ PASSWORD = f"(?:{cset(C_PASSWORD_SAFE)}|{ESCAPED})+"
 PORT = "\\d+"
 
 URI_PARAMCHAR = f"(?:{cset(C_URI_PARAM_SAFE)}|{ESCAPED})"
-URI_GENERIC_PARAM = f"{URI_PARAMCHAR}+(?:={URI_PARAMCHAR}+)?"
+URI_PARAM = f"{URI_PARAMCHAR}+(?:={URI_PARAMCHAR}+)?"
+
+GENERIC_VALUE = f"(?:{TOKEN}|{HOST}|{QUOTED_STRING})"
+GENERIC_PARAM = f"{TOKEN}(?:{EQUAL}{GENERIC_VALUE})?"

--- a/src/sipmessage/parameters.py
+++ b/src/sipmessage/parameters.py
@@ -3,7 +3,13 @@
 # Distributed under the 2-clause BSD license
 #
 
+import re
 from urllib.parse import quote, unquote
+
+from . import grammar
+
+EQUAL_PATTERN = re.compile(grammar.EQUAL)
+SEMI_PATTERN = re.compile(grammar.SEMI)
 
 
 class Parameters(dict[str, str | None]):
@@ -17,10 +23,10 @@ class Parameters(dict[str, str | None]):
         Parse the given string into a :class:`Parameters` instance.
         """
         p = cls()
-        if val:
-            for bit in val.split(";"):
+        for bit in SEMI_PATTERN.split(val):
+            if bit:
                 if "=" in bit:
-                    k, v = bit.split("=", 1)
+                    k, v = EQUAL_PATTERN.split(bit, 1)
                     v = unquote(v)
                 else:
                     k, v = bit, None

--- a/src/sipmessage/uri.py
+++ b/src/sipmessage/uri.py
@@ -16,7 +16,7 @@ URI_PATTERN = re.compile(
     f"(?:(?P<user>{grammar.USER})(?::(?P<password>{grammar.PASSWORD}))?@)?"
     f"(?P<host>{grammar.HOST})"
     f"(?::(?P<port>{grammar.PORT}))?"
-    f"(?P<parameters>(?:;{grammar.URI_GENERIC_PARAM})*)"
+    f"(?P<parameters>(?:;{grammar.URI_PARAM})*)"
     "$"
 )
 
@@ -54,7 +54,7 @@ class URI:
         """
         m = URI_PATTERN.match(value)
         if not m:
-            raise ValueError("Invalid URI")
+            raise ValueError("URI is not valid")
 
         port = m.group("port")
         user = m.group("user")
@@ -67,7 +67,7 @@ class URI:
             port=int(port) if port else None,
             user=urllib.parse.unquote(user) if user else None,
             password=urllib.parse.unquote(password) if password else None,
-            parameters=Parameters.parse(parameters[1:]),
+            parameters=Parameters.parse(parameters),
         )
 
     @property

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -12,12 +12,12 @@ class AddressTest(unittest.TestCase):
     def test_empty(self) -> None:
         with self.assertRaises(ValueError) as cm:
             Address.parse("")
-        self.assertEqual(str(cm.exception), "Not a valid address")
+        self.assertEqual(str(cm.exception), "Address is not valid")
 
     def test_invalid_uri(self) -> None:
         with self.assertRaises(ValueError) as cm:
             Address.parse("atlanta.com")
-        self.assertEqual(str(cm.exception), "Invalid URI")
+        self.assertEqual(str(cm.exception), "URI is not valid")
 
     def test_no_brackets(self) -> None:
         contact = Address.parse("sip:+12125551212@phone2net.com;tag=887s")
@@ -121,7 +121,7 @@ class AddressTest(unittest.TestCase):
         )
         self.assertEqual(str(contact), "<sip:1.2.3.4;lr>")
 
-    def test_rfc4775_esc01_contact(self) -> None:
+    def test_rfc4475_esc01_contact(self) -> None:
         contact = Address.parse(
             "<sip:cal%6Cer@host5.example.net;%6C%72;n%61me=v%61lue%25%34%31>"
         )
@@ -141,7 +141,7 @@ class AddressTest(unittest.TestCase):
             "<sip:caller@host5.example.net;lr;name=value%2541>",
         )
 
-    def test_rfc4775_esc02_from(self) -> None:
+    def test_rfc4475_esc02_from(self) -> None:
         contact = Address.parse('"%Z%45" <sip:resource@example.com>;tag=f232jadfj23')
         self.assertEqual(
             contact,

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -10,9 +10,10 @@ from sipmessage import Parameters
 
 class ParametersTest(unittest.TestCase):
     def test_empty(self) -> None:
-        parameters = Parameters.parse("")
-        self.assertEqual(parameters, {})
-        self.assertEqual(str(parameters), "")
+        for s in ["", ";;;", " ; ; ;"]:
+            parameters = Parameters.parse(s)
+            self.assertEqual(parameters, {})
+            self.assertEqual(str(parameters), "")
 
     def test_escaped(self) -> None:
         parameters = Parameters.parse("%6C%72;n%61me=v%61lue%25%34%31")
@@ -21,5 +22,10 @@ class ParametersTest(unittest.TestCase):
 
     def test_simple(self) -> None:
         parameters = Parameters.parse("foo=1;bar")
+        self.assertEqual(parameters, {"foo": "1", "bar": None})
+        self.assertEqual(str(parameters), "foo=1;bar")
+
+    def test_spaces(self) -> None:
+        parameters = Parameters.parse("foo  =  1  ;  bar")
         self.assertEqual(parameters, {"foo": "1", "bar": None})
         self.assertEqual(str(parameters), "foo=1;bar")

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -13,23 +13,23 @@ class URITest(unittest.TestCase):
         # No port.
         with self.assertRaises(ValueError) as cm:
             URI.parse("sip:atlanta.com:")
-        self.assertEqual(str(cm.exception), "Invalid URI")
+        self.assertEqual(str(cm.exception), "URI is not valid")
 
         # Invalid port.
         with self.assertRaises(ValueError) as cm:
             URI.parse("sip:atlanta.com:bob")
-        self.assertEqual(str(cm.exception), "Invalid URI")
+        self.assertEqual(str(cm.exception), "URI is not valid")
 
     def test_invalid_scheme(self) -> None:
         # No scheme.
         with self.assertRaises(ValueError) as cm:
             URI.parse("atlanta.com")
-        self.assertEqual(str(cm.exception), "Invalid URI")
+        self.assertEqual(str(cm.exception), "URI is not valid")
 
         # Invalid scheme.
         with self.assertRaises(ValueError) as cm:
             URI.parse("bogus:atlanta.com")
-        self.assertEqual(str(cm.exception), "Invalid URI")
+        self.assertEqual(str(cm.exception), "URI is not valid")
 
     def test_host(self) -> None:
         uri = URI.parse("sip:atlanta.com")

--- a/tests/test_via.py
+++ b/tests/test_via.py
@@ -5,32 +5,108 @@
 
 import unittest
 
-from sipmessage import Via
+from sipmessage import Parameters, Via
 
 
 class ViaTest(unittest.TestCase):
     def test_empty(self) -> None:
         with self.assertRaises(ValueError) as cm:
             Via.parse("")
-        self.assertEqual(str(cm.exception), "Malformed Via header")
+        self.assertEqual(str(cm.exception), "Via is not valid")
 
-    def test_parse(self) -> None:
+    def test_hostname(self) -> None:
         via = Via.parse(
-            "SIP/2.0/WSS T8trJdbBz7r6.invalid;branch=z9hG4bKYJHC9fb;received=80.200.136.90;rport=49940"
+            "SIP/2.0/WSS T8trJdbBz7r6.invalid;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940"
         )
-
-        self.assertEqual(via.transport, "WSS")
-        self.assertEqual(via.address, "T8trJdbBz7r6.invalid")
         self.assertEqual(
-            via.parameters,
-            {
-                "branch": "z9hG4bKYJHC9fb",
-                "received": "80.200.136.90",
-                "rport": "49940",
-            },
+            via,
+            Via(
+                transport="WSS",
+                address="T8trJdbBz7r6.invalid",
+                parameters=Parameters(
+                    branch="z9hG4bKYJHC9fb",
+                    received="80.200.136.90",
+                    rport="49940",
+                ),
+            ),
         )
-
         self.assertEqual(
             str(via),
-            "SIP/2.0/WSS T8trJdbBz7r6.invalid;branch=z9hG4bKYJHC9fb;received=80.200.136.90;rport=49940",
+            "SIP/2.0/WSS T8trJdbBz7r6.invalid;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940",
+        )
+
+    def test_hostname_and_port(self) -> None:
+        via = Via.parse(
+            "SIP/2.0/WSS T8trJdbBz7r6.invalid:5060;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940"
+        )
+        self.assertEqual(
+            via,
+            Via(
+                transport="WSS",
+                address="T8trJdbBz7r6.invalid:5060",
+                parameters=Parameters(
+                    branch="z9hG4bKYJHC9fb",
+                    received="80.200.136.90",
+                    rport="49940",
+                ),
+            ),
+        )
+        self.assertEqual(
+            str(via),
+            "SIP/2.0/WSS T8trJdbBz7r6.invalid:5060;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940",
+        )
+
+    def test_ipv4(self) -> None:
+        via = Via.parse(
+            "SIP/2.0/WSS 1.2.3.4;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940"
+        )
+        self.assertEqual(
+            via,
+            Via(
+                transport="WSS",
+                address="1.2.3.4",
+                parameters=Parameters(
+                    branch="z9hG4bKYJHC9fb",
+                    received="80.200.136.90",
+                    rport="49940",
+                ),
+            ),
+        )
+        self.assertEqual(
+            str(via),
+            "SIP/2.0/WSS 1.2.3.4;branch=z9hG4bKYJHC9fb;"
+            "received=80.200.136.90;rport=49940",
+        )
+
+    def test_rfc4475_intmeth(self) -> None:
+        via = Via.parse("SIP/2.0/TCP host1.example.com;branch=z9hG4bK-.!%66*_+`'~")
+        self.assertEqual(
+            via,
+            Via(
+                transport="TCP",
+                address="host1.example.com",
+                parameters=Parameters(branch="z9hG4bK-.!f*_+`'~"),
+            ),
+        )
+        # FIXME: this is unnecessarily quoted
+        self.assertEqual(
+            str(via), "SIP/2.0/TCP host1.example.com;branch=z9hG4bK-.%21f%2A_%2B%60%27~"
+        )
+
+    def test_rfc4475_wsinv(self) -> None:
+        via = Via.parse(
+            "SIP  /    2.0   / UDP  192.168.255.111   ; branch = z9hG4bK30239"
+        )
+        self.assertEqual(
+            via,
+            Via(
+                transport="UDP",
+                address="192.168.255.111",
+                parameters=Parameters(branch="z9hG4bK30239"),
+            ),
         )


### PR DESCRIPTION
`Address` and `Via` parameters may have spaces surrounding:

- the semi-colon
- the equal sign