### PR TITLE
Tighten `Parameters` parsing

### DIFF
--- a/src/sipmessage/address.py
+++ b/src/sipmessage/address.py
@@ -70,7 +70,6 @@ class Address:
 
         If parsing fails, a :class:`ValueError` is raised.
         """
-
         value = grammar.simplify_whitespace(value)
 
         for pattern in ADDRESS_PATTERNS:
@@ -88,7 +87,5 @@ class Address:
         s = ""
         if self.name:
             s += quote(self.name) + " "
-        s += "<%s>" % self.uri
-        if self.parameters:
-            s += ";" + str(self.parameters)
+        s += f"<{self.uri}>{self.parameters}"
         return s

--- a/src/sipmessage/parameters.py
+++ b/src/sipmessage/parameters.py
@@ -18,13 +18,28 @@ class Parameters(dict[str, str | None]):
     """
 
     @classmethod
-    def parse(cls, val: str) -> "Parameters":
+    def parse(cls, value: str) -> "Parameters":
         """
         Parse the given string into a :class:`Parameters` instance.
+
+        If parsing fails, a :class:`ValueError` is raised.
         """
+        value = grammar.simplify_whitespace(value)
+
         p = cls()
-        for bit in SEMI_PATTERN.split(val):
-            if bit:
+        if value:
+            bits = SEMI_PATTERN.split(value)
+
+            # The first "bit" must be empty, as the string must start
+            # with a SEMI.
+            if bits[0]:
+                raise ValueError("Parameters are not valid")
+
+            for bit in bits[1:]:
+                # Empty parameters are not allowed.
+                if not bit:
+                    raise ValueError("Parameters are not valid")
+
                 if "=" in bit:
                     k, v = EQUAL_PATTERN.split(bit, 1)
                     v = unquote(v)
@@ -34,9 +49,9 @@ class Parameters(dict[str, str | None]):
         return p
 
     def __str__(self) -> str:
-        return ";".join(
-            [
-                quote(k) if v is None else (quote(k) + "=" + quote(v))
-                for k, v in self.items()
-            ]
-        )
+        output = ""
+        for k, v in self.items():
+            output += ";" + quote(k)
+            if v is not None:
+                output += "=" + quote(v)
+        return output

--- a/src/sipmessage/uri.py
+++ b/src/sipmessage/uri.py
@@ -100,6 +100,5 @@ class URI:
         s += self.host
         if self.port is not None:
             s += f":{self.port}"
-        if self.parameters:
-            s += ";" + str(self.parameters)
+        s += str(self.parameters)
         return s

--- a/src/sipmessage/via.py
+++ b/src/sipmessage/via.py
@@ -43,7 +43,6 @@ class Via:
 
         If parsing fails, a :class:`ValueError` is raised.
         """
-
         value = grammar.simplify_whitespace(value)
 
         m = VIA_PATTERN.match(value)
@@ -63,6 +62,5 @@ class Via:
         s = f"SIP/2.0/{self.transport} {self.host}"
         if self.port is not None:
             s += f":{self.port}"
-        if self.parameters:
-            s += ";" + str(self.parameters)
+        s += str(self.parameters)
         return s

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -121,6 +121,11 @@ class AddressTest(unittest.TestCase):
         )
         self.assertEqual(str(contact), "<sip:1.2.3.4;lr>")
 
+    def test_rfc4475_badinv01_contact(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            Address.parse('"Joe" <sip:joe@example.org>;;;;')
+        self.assertEqual(str(cm.exception), "Address is not valid")
+
     def test_rfc4475_esc01_contact(self) -> None:
         contact = Address.parse(
             "<sip:cal%6Cer@host5.example.net;%6C%72;n%61me=v%61lue%25%34%31>"

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -10,22 +10,27 @@ from sipmessage import Parameters
 
 class ParametersTest(unittest.TestCase):
     def test_empty(self) -> None:
-        for s in ["", ";;;", " ; ; ;"]:
-            parameters = Parameters.parse(s)
-            self.assertEqual(parameters, {})
-            self.assertEqual(str(parameters), "")
+        parameters = Parameters.parse("")
+        self.assertEqual(parameters, {})
+        self.assertEqual(str(parameters), "")
 
     def test_escaped(self) -> None:
-        parameters = Parameters.parse("%6C%72;n%61me=v%61lue%25%34%31")
+        parameters = Parameters.parse(";%6C%72;n%61me=v%61lue%25%34%31")
         self.assertEqual(parameters, {"lr": None, "name": "value%41"})
-        self.assertEqual(str(parameters), "lr;name=value%2541")
+        self.assertEqual(str(parameters), ";lr;name=value%2541")
+
+    def test_invalid(self) -> None:
+        for s in ["a", ";", " ; ", ";;;", " ; ; ;"]:
+            with self.assertRaises(ValueError) as cm:
+                Parameters.parse(s)
+            self.assertEqual(str(cm.exception), "Parameters are not valid")
 
     def test_simple(self) -> None:
-        parameters = Parameters.parse("foo=1;bar")
+        parameters = Parameters.parse(";foo=1;bar")
         self.assertEqual(parameters, {"foo": "1", "bar": None})
-        self.assertEqual(str(parameters), "foo=1;bar")
+        self.assertEqual(str(parameters), ";foo=1;bar")
 
     def test_spaces(self) -> None:
-        parameters = Parameters.parse("foo  =  1  ;  bar")
+        parameters = Parameters.parse(" ; foo  =  1  ;  bar ")
         self.assertEqual(parameters, {"foo": "1", "bar": None})
-        self.assertEqual(str(parameters), "foo=1;bar")
+        self.assertEqual(str(parameters), ";foo=1;bar")

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -9,6 +9,11 @@ from sipmessage import URI
 
 
 class URITest(unittest.TestCase):
+    def test_invalid_parameters(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            URI.parse("sip:atlanta.com;")
+        self.assertEqual(str(cm.exception), "URI is not valid")
+
     def test_invalid_port(self) -> None:
         # No port.
         with self.assertRaises(ValueError) as cm:

--- a/tests/test_via.py
+++ b/tests/test_via.py
@@ -84,6 +84,11 @@ class ViaTest(unittest.TestCase):
             "received=80.200.136.90;rport=49940",
         )
 
+    def test_rfc4475_badinv01(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            Via.parse("SIP/2.0/UDP 192.0.2.15;;")
+        self.assertEqual(str(cm.exception), "Via is not valid")
+
     def test_rfc4475_intmeth(self) -> None:
         via = Via.parse("SIP/2.0/TCP host1.example.com;branch=z9hG4bK-.!%66*_+`'~")
         self.assertEqual(


### PR DESCRIPTION
Make parsing and serialization symmetrical: the first SEMI is part of the parameters.

Do not allow empty parameters, that is a SEMI followed by another SEMI.