### PR TITLE
Make dataclasses frozen, and `Parameters` an immutable mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # Version
 name = "sipmessage"
-version = "0.3.1"
+version = "0.4.0"
 
 # Dependencies
 dependencies = []

--- a/src/sipmessage/address.py
+++ b/src/sipmessage/address.py
@@ -46,7 +46,7 @@ def unquote(value: str) -> str:
         return value
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Address:
     """
     An address as used in `Contact`, `From`, `Reply-To` and `To` headers.

--- a/src/sipmessage/cseq.py
+++ b/src/sipmessage/cseq.py
@@ -13,7 +13,7 @@ CSEQ_PATTERN = re.compile(
 )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class CSeq:
     """
     A `CSeq` header, used to identity and order transactions.

--- a/src/sipmessage/cseq.py
+++ b/src/sipmessage/cseq.py
@@ -28,7 +28,7 @@ class CSeq:
     @classmethod
     def parse(cls, value: str) -> "CSeq":
         """
-        Parse the given string into an :class:`Address` instance.
+        Parse the given string into an :class:`CSeq` instance.
 
         If parsing fails, a :class:`ValueError` is raised.
         """

--- a/src/sipmessage/uri.py
+++ b/src/sipmessage/uri.py
@@ -21,7 +21,7 @@ URI_PATTERN = re.compile(
 )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class URI:
     """
     A SIP or SIPS URL as described by RFC3261.

--- a/src/sipmessage/via.py
+++ b/src/sipmessage/via.py
@@ -18,7 +18,7 @@ VIA_PATTERN = re.compile(
 )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Via:
     """
     A `Via` header, indicating a reponse location for a transaction.

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -29,7 +29,7 @@ class AddressTest(unittest.TestCase):
                     user="+12125551212",
                     host="phone2net.com",
                 ),
-                parameters=Parameters({"tag": "887s"}),
+                parameters=Parameters(tag="887s"),
             ),
         )
         self.assertEqual(str(contact), "<sip:+12125551212@phone2net.com>;tag=887s")
@@ -47,7 +47,7 @@ class AddressTest(unittest.TestCase):
                     user="c8oqz84zk7z",
                     host="privacy.org",
                 ),
-                parameters=Parameters({"tag": "hyh8"}),
+                parameters=Parameters(tag="hyh8"),
             ),
         )
         self.assertEqual(
@@ -65,7 +65,7 @@ class AddressTest(unittest.TestCase):
                     user="bob",
                     host="biloxi.com",
                 ),
-                parameters=Parameters({"tag": "a48s"}),
+                parameters=Parameters(tag="a48s"),
             ),
         )
         self.assertEqual(str(contact), '"Bob" <sips:bob@biloxi.com>;tag=a48s')
@@ -81,7 +81,7 @@ class AddressTest(unittest.TestCase):
                     user="bob",
                     host="biloxi.com",
                 ),
-                parameters=Parameters({"tag": "a48s"}),
+                parameters=Parameters(tag="a48s"),
             ),
         )
         self.assertEqual(str(contact), '"Bob" <sips:bob@biloxi.com>;tag=a48s')
@@ -100,7 +100,7 @@ class AddressTest(unittest.TestCase):
                     user="bob",
                     host="biloxi.com",
                 ),
-                parameters=Parameters({"tag": "a48s"}),
+                parameters=Parameters(tag="a48s"),
             ),
         )
         self.assertEqual(
@@ -114,9 +114,7 @@ class AddressTest(unittest.TestCase):
         self.assertEqual(
             contact,
             Address(
-                uri=URI(
-                    scheme="sip", host="1.2.3.4", parameters=Parameters({"lr": None})
-                )
+                uri=URI(scheme="sip", host="1.2.3.4", parameters=Parameters(lr=None))
             ),
         )
         self.assertEqual(str(contact), "<sip:1.2.3.4;lr>")
@@ -137,7 +135,7 @@ class AddressTest(unittest.TestCase):
                     scheme="sip",
                     user="caller",
                     host="host5.example.net",
-                    parameters=Parameters({"lr": None, "name": "value%41"}),
+                    parameters=Parameters(lr=None, name="value%41"),
                 ),
             ),
         )
@@ -157,7 +155,7 @@ class AddressTest(unittest.TestCase):
                     user="resource",
                     host="example.com",
                 ),
-                parameters=Parameters({"tag": "f232jadfj23"}),
+                parameters=Parameters(tag="f232jadfj23"),
             ),
         )
         self.assertEqual(
@@ -174,7 +172,7 @@ class AddressTest(unittest.TestCase):
                     host="example.com",
                     user="null-\x00-null",
                 ),
-                parameters=Parameters({"tag": "839923423"}),
+                parameters=Parameters(tag="839923423"),
             ),
         )
         self.assertEqual(str(contact), "<sip:null-%00-null@example.com>;tag=839923423")

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -12,6 +12,8 @@ class ParametersTest(unittest.TestCase):
     def test_empty(self) -> None:
         parameters = Parameters.parse("")
         self.assertEqual(parameters, {})
+        self.assertEqual(len(parameters), 0)
+        self.assertEqual(repr(parameters), "Parameters()")
         self.assertEqual(str(parameters), "")
 
     def test_escaped(self) -> None:
@@ -25,9 +27,18 @@ class ParametersTest(unittest.TestCase):
                 Parameters.parse(s)
             self.assertEqual(str(cm.exception), "Parameters are not valid")
 
+    def test_replace(self) -> None:
+        parameters1 = Parameters(foo="1", bar=None)
+        parameters2 = parameters1.replace(tag="blah")
+
+        self.assertEqual(str(parameters1), ";foo=1;bar")
+        self.assertEqual(str(parameters2), ";foo=1;bar;tag=blah")
+
     def test_simple(self) -> None:
         parameters = Parameters.parse(";foo=1;bar")
         self.assertEqual(parameters, {"foo": "1", "bar": None})
+        self.assertEqual(len(parameters), 2)
+        self.assertEqual(repr(parameters), "Parameters(foo='1', bar=None)")
         self.assertEqual(str(parameters), ";foo=1;bar")
 
     def test_spaces(self) -> None:


### PR DESCRIPTION
Having immutable objecs avoids many footguns by making it impossible to perform updates on shared object instances.