### PR TITLE
Fix `Parameters.__getitem__` implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # Version
 name = "sipmessage"
-version = "0.4.0"
+version = "0.4.1"
 
 # Dependencies
 dependencies = []

--- a/src/sipmessage/parameters.py
+++ b/src/sipmessage/parameters.py
@@ -62,7 +62,7 @@ class Parameters(Mapping[str, str | None]):
         return Parameters(**data)
 
     def __getitem__(self, key: str) -> str | None:
-        return self.__data.get(key)
+        return self.__data[key]
 
     def __iter__(self) -> Iterator[str]:
         return iter(self.__data)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -41,6 +41,20 @@ class ParametersTest(unittest.TestCase):
         self.assertEqual(repr(parameters), "Parameters(foo='1', bar=None)")
         self.assertEqual(str(parameters), ";foo=1;bar")
 
+        # Check mapping access.
+        self.assertTrue("foo" in parameters)
+        self.assertTrue("bar" in parameters)
+        self.assertFalse("baz" in parameters)
+
+        self.assertEqual(parameters["foo"], "1")
+        self.assertEqual(parameters["bar"], None)
+        with self.assertRaises(KeyError):
+            parameters["baz"]
+
+        self.assertEqual(parameters.get("foo"), "1")
+        self.assertEqual(parameters.get("bar"), None)
+        self.assertEqual(parameters.get("baz"), None)
+
     def test_spaces(self) -> None:
         parameters = Parameters.parse(" ; foo  =  1  ;  bar ")
         self.assertEqual(parameters, {"foo": "1", "bar": None})


### PR DESCRIPTION
The implementation of `__getitem__` incorrectly used `.get` to access the underlying dict, resulting in `x in parameters` always returning `True`, even for keys not present in the parameters.