### PR TITLE
Add support for parsing authentication headers

### DIFF
--- a/src/sipmessage/__init__.py
+++ b/src/sipmessage/__init__.py
@@ -6,10 +6,20 @@
 import importlib.metadata
 
 from .address import Address
+from .auth import AuthChallenge, AuthCredentials, AuthParameters
 from .cseq import CSeq
 from .parameters import Parameters
 from .uri import URI
 from .via import Via
 
-__all__ = ["Address", "CSeq", "Parameters", "URI", "Via"]
+__all__ = [
+    "Address",
+    "AuthChallenge",
+    "AuthCredentials",
+    "AuthParameters",
+    "CSeq",
+    "Parameters",
+    "URI",
+    "Via",
+]
 __version__ = importlib.metadata.version("sipmessage")

--- a/src/sipmessage/auth.py
+++ b/src/sipmessage/auth.py
@@ -1,0 +1,188 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+import dataclasses
+import re
+from collections.abc import Iterator, Mapping
+
+from . import grammar
+from .address import quote, unquote
+
+AUTH_CHALLENGE_PATTERN = re.compile(
+    f"^(?P<scheme>{grammar.TOKEN}){grammar.LWS}"
+    f"(?P<parameters>{grammar.AUTH_PARAM}(?:{grammar.COMMA}{grammar.AUTH_PARAM})*)"
+    "$"
+)
+AUTH_CREDENTIALS_PATTERN = re.compile(
+    f"^(?P<scheme>{grammar.TOKEN}){grammar.LWS}"
+    f"(?P<parameters>(?:{grammar.TOKEN}|{grammar.AUTH_PARAM}(?:{grammar.COMMA}{grammar.AUTH_PARAM})*))"
+    "$"
+)
+
+COMMA_PATTERN = re.compile(f"{grammar.SWS}{grammar.COMMA}{grammar.SWS}")
+EQUAL_PATTERN = re.compile(f"{grammar.SWS}{grammar.EQUAL}{grammar.SWS}")
+TOKEN_PATTERN = re.compile("^" + grammar.TOKEN + "$")
+
+QUOTED_PARAMETERS = frozenset(
+    ["cnonce", "domain", "nonce", "opaque", "qop", "realm", "response", "username"]
+)
+
+
+def maybe_quote(v: str, force_quote: bool) -> str:
+    if TOKEN_PATTERN.match(v) and not force_quote:
+        return v
+    else:
+        return quote(v)
+
+
+class AuthParameters(Mapping[str, str]):
+    """
+    A mapping of :class:`AuthChallenge` or :class:`AuthCredentials` parameters.
+    """
+
+    def __init__(self, **kwargs: str) -> None:
+        self.__data = dict(kwargs)
+
+    @classmethod
+    def parse(cls, value: str) -> "AuthParameters":
+        """
+        Parse the given string into a :class:`AuthParameters` instance.
+
+        If parsing fails, a :class:`ValueError` is raised.
+        """
+        data: dict[str, str] = {}
+        value = value.strip()
+        if value:
+            bits = COMMA_PATTERN.split(value)
+
+            for bit in bits:
+                # Empty parameters are not allowed.
+                if "=" not in bit:
+                    raise ValueError("AuthParameters are not valid")
+
+                k, v = EQUAL_PATTERN.split(bit, 1)
+                data[unquote(k)] = unquote(v)
+        return cls(**data)
+
+    def replace(self, **changes: str) -> "AuthParameters":
+        """
+        Return a copy of the parameters, updated with the given `changes`.
+        """
+        data = {}
+        data.update(self.__data)
+        data.update(**changes)
+        return AuthParameters(**data)
+
+    def __getitem__(self, key: str) -> str:
+        return self.__data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__data)
+
+    def __len__(self) -> int:
+        return len(self.__data)
+
+    def __repr__(self) -> str:
+        data = ""
+        for k, v in self.items():
+            if data:
+                data += ", "
+            data += f"{k}={v!r}"
+        return f"AuthParameters({data})"
+
+    def __str__(self) -> str:
+        bits = [
+            k + "=" + maybe_quote(v, force_quote=k in QUOTED_PARAMETERS)
+            for (k, v) in self.items()
+        ]
+        return ", ".join(bits)
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthChallenge:
+    """
+    A `WWW-Authenticate` or `Proxy-Authenticate` header, used to convey
+    an authentication challenge.
+    """
+
+    scheme: str
+    'The authentication scheme, e.g. `"Digest"`.'
+
+    parameters: AuthParameters = dataclasses.field(default_factory=AuthParameters)
+    "The authentication parameters."
+
+    @classmethod
+    def parse(cls, value: str) -> "AuthChallenge":
+        """
+        Parse the given string into an :class:`AuthChallenge` instance.
+
+        If parsing fails, a :class:`ValueError` is raised.
+        """
+        m = AUTH_CHALLENGE_PATTERN.match(value)
+        if m is None:
+            raise ValueError("AuthChallenge is not valid")
+
+        return cls(
+            scheme=m.group("scheme"),
+            parameters=AuthParameters.parse(m.group("parameters")),
+        )
+
+    def __str__(self) -> str:
+        s = self.scheme.title()
+        if self.parameters:
+            s += " " + str(self.parameters)
+        return s
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthCredentials:
+    """
+    An `Authorization`, `Proxy-Authorization` header, used to convey
+    authentication credentials.
+    """
+
+    scheme: str
+    'The authentication scheme, e.g. `"Digest"`.'
+
+    parameters: AuthParameters | None = None
+    "The authentication parameters."
+
+    token: str | None = None
+    "The authentication token."
+
+    @classmethod
+    def parse(cls, value: str) -> "AuthCredentials":
+        """
+        Parse the given string into an :class:`AuthCredentials` instance.
+
+        If parsing fails, a :class:`ValueError` is raised.
+        """
+        m = AUTH_CREDENTIALS_PATTERN.match(value)
+        if m is None:
+            raise ValueError("AuthCredentials are not valid")
+
+        if TOKEN_PATTERN.match(m.group("parameters")):
+            return cls(
+                scheme=m.group("scheme"),
+                parameters=None,
+                token=m.group("parameters"),
+            )
+        else:
+            return cls(
+                scheme=m.group("scheme"),
+                parameters=AuthParameters.parse(m.group("parameters")),
+            )
+
+    def __post_init__(self) -> None:
+        if (self.parameters is None) == (self.token is None):
+            raise ValueError("Exactly one of `parameters` or `token` must be set.")
+
+    def __str__(self) -> str:
+        s = self.scheme.title()
+        if self.token:
+            s += " " + self.token
+        elif self.parameters:
+            s += " " + str(self.parameters)
+        return s

--- a/src/sipmessage/grammar.py
+++ b/src/sipmessage/grammar.py
@@ -46,6 +46,7 @@ SWS = "[ ]*"
 TOKEN = f"{cset(C_TOKEN)}+"
 QUOTED_STRING = '"(?:[^"]|\\")*"'
 
+COMMA = f"{SWS},{SWS}"
 EQUAL = f"{SWS}={SWS}"
 SEMI = f"{SWS};{SWS}"
 SLASH = f"{SWS}/{SWS}"
@@ -70,3 +71,5 @@ URI_PARAM = f"{URI_PARAMCHAR}+(?:={URI_PARAMCHAR}+)?"
 
 GENERIC_VALUE = f"(?:{TOKEN}|{HOST}|{QUOTED_STRING})"
 GENERIC_PARAM = f"{TOKEN}(?:{EQUAL}{GENERIC_VALUE})?"
+
+AUTH_PARAM = f"{TOKEN}{EQUAL}(?:{TOKEN}|{QUOTED_STRING})"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,178 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+import unittest
+
+from sipmessage import AuthChallenge, AuthCredentials, AuthParameters
+
+
+class AuthChallengeTest(unittest.TestCase):
+    def test_empty(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            AuthChallenge.parse("")
+        self.assertEqual(str(cm.exception), "AuthChallenge is not valid")
+
+    def test_bearer(self) -> None:
+        auth = AuthChallenge.parse('Bearer realm="atlanta.com"')
+        self.assertEqual(
+            auth,
+            AuthChallenge(
+                scheme="Bearer", parameters=AuthParameters(realm="atlanta.com")
+            ),
+        )
+        self.assertEqual(str(auth), 'Bearer realm="atlanta.com"')
+
+    def test_digest(self) -> None:
+        auth = AuthChallenge.parse(
+            'Digest realm="atlanta.com", '
+            'domain="sip:boxesbybob.com", qop="auth", '
+            'nonce="f84f1cec41e6cbe5aea9c8e88d359", '
+            'opaque="", stale=FALSE, algorithm=MD5'
+        )
+        self.assertEqual(
+            auth,
+            AuthChallenge(
+                scheme="Digest",
+                parameters=AuthParameters(
+                    realm="atlanta.com",
+                    domain="sip:boxesbybob.com",
+                    qop="auth",
+                    nonce="f84f1cec41e6cbe5aea9c8e88d359",
+                    opaque="",
+                    stale="FALSE",
+                    algorithm="MD5",
+                ),
+            ),
+        )
+        self.assertEqual(
+            str(auth),
+            'Digest realm="atlanta.com", '
+            'domain="sip:boxesbybob.com", qop="auth", '
+            'nonce="f84f1cec41e6cbe5aea9c8e88d359", '
+            'opaque="", stale=FALSE, algorithm=MD5',
+        )
+
+
+class AuthCredentialsTest(unittest.TestCase):
+    def test_empty(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            AuthCredentials.parse("")
+        self.assertEqual(str(cm.exception), "AuthCredentials are not valid")
+
+    def test_bearer(self) -> None:
+        auth = AuthCredentials.parse("Bearer sometoken")
+        self.assertEqual(
+            auth,
+            AuthCredentials(scheme="Bearer", token="sometoken"),
+        )
+        self.assertEqual(str(auth), "Bearer sometoken")
+
+    def test_digest(self) -> None:
+        auth = AuthCredentials.parse(
+            'Digest username="bob", '
+            'realm="biloxi.com", '
+            'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '
+            'uri="sip:bob@biloxi.com", '
+            'qop="auth", '
+            "nc=00000001, "
+            'cnonce="0a4f113b", '
+            'response="6629fae49393a05397450978507c4ef1", '
+            'opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+        )
+        self.assertEqual(
+            auth,
+            AuthCredentials(
+                scheme="Digest",
+                parameters=AuthParameters(
+                    username="bob",
+                    realm="biloxi.com",
+                    nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+                    uri="sip:bob@biloxi.com",
+                    qop="auth",
+                    nc="00000001",
+                    cnonce="0a4f113b",
+                    response="6629fae49393a05397450978507c4ef1",
+                    opaque="5ccc069c403ebaf9f0171e9517f40e41",
+                ),
+            ),
+        )
+        self.assertEqual(
+            str(auth),
+            'Digest username="bob", '
+            'realm="biloxi.com", '
+            'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '
+            'uri="sip:bob@biloxi.com", '
+            'qop="auth", '
+            "nc=00000001, "
+            'cnonce="0a4f113b", '
+            'response="6629fae49393a05397450978507c4ef1", '
+            'opaque="5ccc069c403ebaf9f0171e9517f40e41"',
+        )
+
+    def test_invalid_constructor(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            AuthCredentials(scheme="Digest")
+        self.assertEqual(
+            str(cm.exception),
+            "Exactly one of `parameters` or `token` must be set.",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            AuthCredentials(
+                scheme="Digest",
+                parameters=AuthParameters(realm="Some Realm"),
+                token="sometoken",
+            )
+        self.assertEqual(
+            str(cm.exception),
+            "Exactly one of `parameters` or `token` must be set.",
+        )
+
+
+class AuthParametersTest(unittest.TestCase):
+    def test_empty(self) -> None:
+        parameters = AuthParameters.parse("")
+        self.assertEqual(parameters, {})
+        self.assertEqual(len(parameters), 0)
+        self.assertEqual(repr(parameters), "AuthParameters()")
+        self.assertEqual(str(parameters), "")
+
+    def test_invalid(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            AuthParameters.parse("a")
+        self.assertEqual(str(cm.exception), "AuthParameters are not valid")
+
+    def test_replace(self) -> None:
+        parameters1 = AuthParameters(foo="1", bar="2")
+        parameters2 = parameters1.replace(tag="blah")
+
+        self.assertEqual(str(parameters1), "foo=1, bar=2")
+        self.assertEqual(str(parameters2), "foo=1, bar=2, tag=blah")
+
+    def test_simple(self) -> None:
+        parameters = AuthParameters.parse("foo=1,bar=2")
+        self.assertEqual(parameters, {"foo": "1", "bar": "2"})
+        self.assertEqual(len(parameters), 2)
+        self.assertEqual(repr(parameters), "AuthParameters(foo='1', bar='2')")
+        self.assertEqual(str(parameters), "foo=1, bar=2")
+
+        # Check mapping access.
+        self.assertTrue("foo" in parameters)
+        self.assertTrue("bar" in parameters)
+        self.assertFalse("baz" in parameters)
+
+        self.assertEqual(parameters["foo"], "1")
+        self.assertEqual(parameters["bar"], "2")
+        with self.assertRaises(KeyError):
+            parameters["baz"]
+
+        self.assertEqual(parameters.get("foo"), "1")
+        self.assertEqual(parameters.get("bar"), "2")
+        self.assertEqual(parameters.get("baz"), None)
+
+    def test_spaces(self) -> None:
+        parameters = AuthParameters.parse(' foo   = " 1   ",  bar  =2')
+        self.assertEqual(parameters, {"foo": " 1   ", "bar": "2"})
+        self.assertEqual(str(parameters), 'foo=" 1   ", bar=2')


### PR DESCRIPTION
Authentication challenges and credentials follow the same grammar.