### PR TITLE
Update readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,6 @@ python:
   install:
     - method: pip
       path: .
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
 Specifying the `sphinx` configuration file is now required.