### PR TITLE
Add `Message`, `Request`, `Response` classes

### DIFF
--- a/docs/headers.rst
+++ b/docs/headers.rst
@@ -1,0 +1,23 @@
+Headers
+=======
+
+.. autoclass:: sipmessage.Address
+   :members:
+
+.. autoclass:: sipmessage.AuthChallenge
+   :members:
+
+.. autoclass:: sipmessage.AuthCredentials
+   :members:
+
+.. autoclass:: sipmessage.AuthParameters
+   :members:
+
+.. autoclass:: sipmessage.CSeq
+   :members:
+
+.. autoclass:: sipmessage.Parameters
+   :members:
+
+.. autoclass:: sipmessage.Via
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ for parsing SIP messages.
 API Reference
 -------------
 
-.. automodule:: sipmessage
-   :members:
-
 .. toctree::
    :maxdepth: 2
+
+   messages
+   headers

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -1,0 +1,15 @@
+Messages
+========
+
+.. autoclass:: sipmessage.Message
+   :members: parse
+
+.. autoclass:: sipmessage.Request
+   :members:
+   :inherited-members:
+   :exclude-members: parse
+
+.. autoclass:: sipmessage.Response
+   :members:
+   :inherited-members:
+   :exclude-members: parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,6 @@ select = [
     "I",  # isort
     "T20",  # flake8-print
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/test_message.py" = ["E501"]

--- a/src/sipmessage/__init__.py
+++ b/src/sipmessage/__init__.py
@@ -8,6 +8,7 @@ import importlib.metadata
 from .address import Address
 from .auth import AuthChallenge, AuthCredentials, AuthParameters
 from .cseq import CSeq
+from .message import Message, Request, Response
 from .parameters import Parameters
 from .uri import URI
 from .via import Via
@@ -18,7 +19,10 @@ __all__ = [
     "AuthCredentials",
     "AuthParameters",
     "CSeq",
+    "Message",
     "Parameters",
+    "Request",
+    "Response",
     "URI",
     "Via",
 ]

--- a/src/sipmessage/message.py
+++ b/src/sipmessage/message.py
@@ -1,0 +1,458 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+import dataclasses
+from typing import Union
+
+from .address import Address
+from .auth import AuthChallenge, AuthCredentials
+from .cseq import CSeq
+from .uri import URI
+from .via import Via
+
+
+class Headers:
+    def __init__(self) -> None:
+        self._list: list[tuple[str, list[str]]] = []
+
+    def add(self, key: str, value: str) -> None:
+        """
+        Add a new header.
+        """
+        ikey = key.lower()
+        for i, (k, values) in enumerate(self._list):
+            if k.lower() == ikey:
+                values.append(value)
+                break
+        else:
+            self._list.append((key, [value]))
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """
+        Return the first value for the given header or `default`.
+        """
+        ikey = key.lower()
+        for k, values in self._list:
+            if k.lower() == ikey:
+                return values[0]
+        return default
+
+    def getlist(self, key: str) -> list[str]:
+        """
+        Return all the values for the given header.
+        """
+        ikey = key.lower()
+        for k, values in self._list:
+            if k.lower() == ikey:
+                return values
+        return []
+
+    def remove(self, key: str) -> None:
+        """
+        Remove the given header.
+        """
+        ikey = key.lower()
+        for i, (k, _values) in enumerate(self._list[:]):
+            if k.lower() == ikey:
+                self._list.pop(i)
+                break
+
+    def set(self, key: str, value: str) -> None:
+        """
+        Remove all values for the given header and replace them
+        with the given `value`.
+        """
+        ikey = key.lower()
+        for i, (k, _values) in enumerate(self._list[:]):
+            if k.lower() == ikey:
+                self._list[i] = (k, [value])
+                break
+        else:
+            self._list.append((key, [value]))
+
+    def setlist(self, key: str, values: list[str]) -> None:
+        """
+        Remove all values for the given header and replace them
+        with the given `values`.
+        """
+        ikey = key.lower()
+        for i, (k, _values) in enumerate(self._list[:]):
+            if k.lower() == ikey:
+                self._list[i] = (k, values)
+                break
+        else:
+            self._list.append((key, values))
+
+    def __getitem__(self, key: str) -> str:
+        ikey = key.lower()
+        for k, values in self._list:
+            if k.lower() == ikey:
+                return values[0]
+        raise KeyError
+
+    def __str__(self) -> str:
+        output = ""
+        for k, values in self._list:
+            for value in values:
+                output += f"{k}: {value}\r\n"
+        return output + "\r\n"
+
+
+class Message:
+    body: str
+
+    _headers: Headers
+
+    @staticmethod
+    def parse(data: str) -> Union["Request", "Response"]:
+        """
+        Parse the given string into a :class:`Request` or :class:`Response` instance.
+
+        If parsing fails, a :class:`ValueError` is raised.
+        """
+
+        lines = data.split("\r\n")
+        if len(lines) < 2:
+            raise ValueError("SIP message has too few lines")
+
+        # parse first line
+        bits = lines.pop(0).split(" ", 2)
+        message: Request | Response
+        if len(bits) > 2 and bits[2] == "SIP/2.0":
+            message = Request(method=bits[0], uri=URI.parse(bits[1]))
+        elif len(bits) > 2 and bits[0] == "SIP/2.0":
+            message = Response(code=int(bits[1]), phrase=bits[2])
+        else:
+            raise ValueError("SIP message is neither request nor response")
+
+        while len(lines):
+            line = lines.pop(0)
+            if line == "":
+                message.body = "\r\n".join(lines)
+                break
+            key, val = line.split(":", 1)
+            message._headers.add(key, val.strip())
+
+        return message
+
+    @property
+    def authorization(self) -> AuthCredentials | None:
+        """
+        The `Authorization` header value.
+
+        :rfc:`3261#section-20.7`
+        """
+        return self._get_auth_credentials("Authorization")
+
+    @authorization.setter
+    def authorization(self, value: AuthCredentials | None) -> None:
+        self._set_auth_credentials("Authorization", value)
+
+    @property
+    def call_id(self) -> str:
+        """
+        The `Call-ID` header value.
+
+        :rfc:`3261#section-20.8`
+        """
+        return self._headers["Call-ID"]
+
+    @call_id.setter
+    def call_id(self, value: str) -> None:
+        self._headers.set("Call-ID", value)
+
+    @property
+    def contact(self) -> list[Address]:
+        """
+        The `Contact` header values.
+
+        :rfc:`3261#section-20.10`
+        """
+        return self._get_address_list("Contact")
+
+    @contact.setter
+    def contact(self, value: list[Address]) -> None:
+        self._set_address_list("Contact", value)
+
+    @property
+    def content_length(self) -> int | None:
+        """
+        The `Content-Length` header value.
+
+        :rfc:`3261#section-20.14`
+        """
+        return self._get_optional_int("Content-Length")
+
+    @content_length.setter
+    def content_length(self, value: int | None) -> None:
+        self._set_optional_int("Content-Length", value)
+
+    @property
+    def content_type(self) -> str | None:
+        """
+        The `Content-Length` header value.
+
+        :rfc:`3261#section-20.15`
+        """
+        return self._get_optional_str("Content-Type")
+
+    @content_type.setter
+    def content_type(self, value: str | None) -> None:
+        self._set_optional_str("Content-Type", value)
+
+    @property
+    def cseq(self) -> CSeq:
+        """
+        The `CSeq` header value.
+
+        :rfc:`3261#section-20.16`
+        """
+        return CSeq.parse(self._headers["CSeq"])
+
+    @cseq.setter
+    def cseq(self, value: CSeq) -> None:
+        self._headers.set("CSeq", str(value))
+
+    @property
+    def from_address(self) -> Address:
+        """
+        The `From` header value.
+
+        :rfc:`3261#section-20.20`
+        """
+        return Address.parse(self._headers["From"])
+
+    @from_address.setter
+    def from_address(self, value: Address) -> None:
+        self._headers.set("From", str(value))
+
+    @property
+    def max_forwards(self) -> int | None:
+        """
+        The `Max-Forwards` header value.
+
+        :rfc:`3261#section-20.22`
+        """
+        return self._get_optional_int("Max-Forwards")
+
+    @max_forwards.setter
+    def max_forwards(self, value: int | None) -> None:
+        self._set_optional_int("Max-Forwards", value)
+
+    @property
+    def proxy_authenticate(self) -> AuthChallenge | None:
+        """
+        The `Proxy-Authenticate` header value.
+
+        :rfc:`3261#section-20.27`
+        """
+        return self._get_auth_challenge("Proxy-Authenticate")
+
+    @proxy_authenticate.setter
+    def proxy_authenticate(self, value: AuthChallenge | None) -> None:
+        self._set_auth_challenge("Proxy-Authenticate", value)
+
+    @property
+    def proxy_authorization(self) -> AuthCredentials | None:
+        """
+        The `Proxy-Authorization` header value.
+
+        :rfc:`3261#section-20.28`
+        """
+        return self._get_auth_credentials("Proxy-Authorization")
+
+    @proxy_authorization.setter
+    def proxy_authorization(self, value: AuthCredentials | None) -> None:
+        self._set_auth_credentials("Proxy-Authorization", value)
+
+    @property
+    def to_address(self) -> Address:
+        """
+        The `To` header value value.
+
+        :rfc:`3261#section-20.39`
+        """
+        return Address.parse(self._headers["To"])
+
+    @to_address.setter
+    def to_address(self, value: Address) -> None:
+        self._headers.set("To", str(value))
+
+    @property
+    def record_route(self) -> list[Address]:
+        """
+        The `Record-Route` header values.
+
+        :rfc:`3261#section-20.30`
+        """
+        return self._get_address_list("Record-Route")
+
+    @record_route.setter
+    def record_route(self, value: list[Address]) -> None:
+        self._set_address_list("Record-Route", value)
+
+    @property
+    def route(self) -> list[Address]:
+        """
+        The `Route` header values.
+
+        :rfc:`3261#section-20.34`
+        """
+        return self._get_address_list("Route")
+
+    @route.setter
+    def route(self, value: list[Address]) -> None:
+        self._set_address_list("Route", value)
+
+    @property
+    def user_agent(self) -> str | None:
+        """
+        The `User-Agent` header value.
+
+        :rfc:`3261#section-20.41`
+        """
+        return self._get_optional_str("User-Agent")
+
+    @user_agent.setter
+    def user_agent(self, value: str | None) -> None:
+        self._set_optional_str("User-Agent", value)
+
+    @property
+    def via(self) -> list[Via]:
+        """
+        The `Via` header values.
+
+        :rfc:`3261#section-20.42`
+        """
+        headers: list[Via] = []
+        for value in self._headers.getlist("Via"):
+            headers += Via.parse_many(value)
+        return headers
+
+    @via.setter
+    def via(self, value: list[Via]) -> None:
+        self._headers.setlist("Via", [str(x) for x in value])
+
+    @property
+    def www_authenticate(self) -> AuthChallenge | None:
+        """
+        The `WWW-Authenticate` header values.
+
+        :rfc:`3261#section-20.44`
+        """
+        return self._get_auth_challenge("WWW-Authenticate")
+
+    @www_authenticate.setter
+    def www_authenticate(self, value: AuthChallenge | None) -> None:
+        self._set_auth_challenge("WWW-Authenticate", value)
+
+    def _get_address_list(self, key: str) -> list[Address]:
+        headers: list[Address] = []
+        for value in self._headers.getlist(key):
+            headers += Address.parse_many(value)
+        return headers
+
+    def _set_address_list(self, key: str, value: list[Address]) -> None:
+        self._headers.setlist(key, [str(x) for x in value])
+
+    def _get_auth_challenge(self, key: str) -> AuthChallenge | None:
+        value = self._headers.get(key, None)
+        if value is None:
+            return None
+        else:
+            return AuthChallenge.parse(value)
+
+    def _set_auth_challenge(self, key: str, value: AuthChallenge | None) -> None:
+        if value is None:
+            self._headers.remove(key)
+        else:
+            self._headers.set(key, str(value))
+
+    def _get_auth_credentials(self, key: str) -> AuthCredentials | None:
+        value = self._headers.get(key, None)
+        if value is None:
+            return None
+        else:
+            return AuthCredentials.parse(value)
+
+    def _set_auth_credentials(self, key: str, value: AuthCredentials | None) -> None:
+        if value is None:
+            self._headers.remove(key)
+        else:
+            self._headers.set(key, str(value))
+
+    def _get_optional_int(self, key: str) -> int | None:
+        value = self._headers.get(key, None)
+        if value is None:
+            return None
+        else:
+            return int(value)
+
+    def _set_optional_int(self, key: str, value: int | None) -> None:
+        if value is None:
+            self._headers.remove(key)
+        else:
+            self._headers.set(key, str(value))
+
+    def _get_optional_str(self, key: str) -> str | None:
+        return self._headers.get(key, None)
+
+    def _set_optional_str(self, key: str, value: str | None) -> None:
+        if value is None:
+            self._headers.remove(key)
+        else:
+            self._headers.set(key, value)
+
+
+@dataclasses.dataclass
+class Request(Message):
+    """
+    A SIP request.
+    """
+
+    method: str
+    "The request method."
+
+    uri: URI
+    "The request URI."
+
+    body: str = ""
+    "The request body."
+
+    _headers: Headers = dataclasses.field(default_factory=Headers)
+
+    def __str__(self) -> str:
+        return "%s %s SIP/2.0\r\n%s%s" % (
+            self.method,
+            self.uri,
+            self._headers,
+            self.body,
+        )
+
+
+@dataclasses.dataclass
+class Response(Message):
+    """
+    A SIP response.
+    """
+
+    code: int
+    "The response code."
+
+    phrase: str
+    "The response phrase."
+
+    body: str = ""
+    "The response body."
+
+    _headers: Headers = dataclasses.field(default_factory=Headers)
+
+    def __str__(self) -> str:
+        return "SIP/2.0 %s %s\r\n%s%s" % (
+            self.code,
+            self.phrase,
+            self._headers,
+            self.body,
+        )

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,451 @@
+#
+# Copyright (C) Spacinov SAS
+# Distributed under the 2-clause BSD license
+#
+
+import unittest
+
+from sipmessage import (
+    URI,
+    Address,
+    AuthChallenge,
+    AuthCredentials,
+    AuthParameters,
+    CSeq,
+    Message,
+    Parameters,
+    Request,
+    Response,
+    Via,
+)
+from sipmessage.message import Headers
+
+ADDRESS = Address(uri=URI(scheme="sip", host="example.com"))
+AUTHENTICATE = AuthChallenge(
+    "Digest",
+    parameters=AuthParameters(
+        realm="atlanta.com",
+        domain="sip:boxesbybob.com",
+        qop="auth",
+        nonce="f84f1cec41e6cbe5aea9c8e88d359",
+        opaque="",
+        stale="FALSE",
+        algorithm="MD5",
+    ),
+)
+AUTHORIZATION = AuthCredentials(
+    "Digest",
+    parameters=AuthParameters(
+        username="Alice",
+        realm="atlanta.com",
+        nonce="84a4cc6f3082121f32b42a2187831a9e",
+        response="7587245234b3434cc3412213e5f113a5432",
+    ),
+)
+CSEQ = CSeq(sequence=1, method="OPTIONS")
+VIA = Via(
+    transport="WSS",
+    host="mYn6S3lQaKjo.invalid",
+    parameters=Parameters(branch="z9hG4bKgD24yaj"),
+)
+
+
+def dummy_message() -> Request:
+    return Request("OPTIONS", URI(scheme="sip", host="example.com"))
+
+
+def lf2crlf(x: str) -> str:
+    return x.replace("\n", "\r\n")
+
+
+class HeadersTest(unittest.TestCase):
+    def test_add(self) -> None:
+        headers = Headers()
+
+        headers.add(
+            "Via", "SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1"
+        )
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+
+"""),
+        )
+
+        headers.add(
+            "Via",
+            "SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1",
+        )
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1
+
+"""),
+        )
+
+        headers.add("From", "<sip:alice@atlanta.com>")
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1
+From: <sip:alice@atlanta.com>
+
+"""),
+        )
+
+    def test_set(self) -> None:
+        headers = Headers()
+
+        headers.set("To", "Bob <sip:bob@biloxi.com>")
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""To: Bob <sip:bob@biloxi.com>
+
+"""),
+        )
+
+        headers.set("To", "Alice <sip:alice@biloxi.com>")
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""To: Alice <sip:alice@biloxi.com>
+
+"""),
+        )
+
+    def test_setlist(self) -> None:
+        headers = Headers()
+
+        headers.setlist(
+            "Via",
+            ["SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1"],
+        )
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+
+"""),
+        )
+
+        headers.setlist(
+            "Via",
+            [
+                "SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1",
+                "SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1",
+            ],
+        )
+        self.assertEqual(
+            str(headers),
+            lf2crlf("""Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1
+
+"""),
+        )
+
+
+class MessageTest(unittest.TestCase):
+    maxDiff = None
+
+    def assertMessageHeaders(self, request: Message, values: list[str]) -> None:
+        self.assertEqual(str(request).split("\r\n")[1:-2], values)
+
+    def test_request(self) -> None:
+        message_str = lf2crlf(
+            """REGISTER sip:atlanta.com SIP/2.0
+Via: SIP/2.0/WSS mYn6S3lQaKjo.invalid;branch=z9hG4bKgD24yaj
+Max-Forwards: 70
+To: <sip:alice@atlanta.com>
+From: <sip:alice@atlanta.com>;tag=69piINLbAb
+Call-ID: t87Br1RHAoBz2FsrKKk6hV
+CSeq: 1 REGISTER
+Contact: <sip:Mk9sZp5Z@mYn6S3lQaKjo.invalid;transport=ws>;expires=300
+User-Agent: Tester/0.1.0
+Content-Length: 0
+
+"""
+        )
+
+        message = Message.parse(message_str)
+        assert isinstance(message, Request)
+
+        self.assertEqual(message.method, "REGISTER")
+        self.assertEqual(message.uri, URI(scheme="sip", host="atlanta.com"))
+        self.assertEqual(message.body, "")
+
+        # Check headers.
+        self.assertEqual(message.call_id, "t87Br1RHAoBz2FsrKKk6hV")
+        self.assertEqual(message.content_type, None)
+        self.assertEqual(message.content_length, 0)
+        self.assertEqual(message.cseq, CSeq(sequence=1, method="REGISTER"))
+        self.assertEqual(
+            message.contact,
+            [
+                Address(
+                    uri=URI(
+                        scheme="sip",
+                        host="mYn6S3lQaKjo.invalid",
+                        user="Mk9sZp5Z",
+                        parameters=Parameters(transport="ws"),
+                    ),
+                    parameters=Parameters(expires="300"),
+                )
+            ],
+        )
+        self.assertEqual(
+            message.from_address,
+            Address(
+                uri=URI(scheme="sip", host="atlanta.com", user="alice"),
+                parameters=Parameters(tag="69piINLbAb"),
+            ),
+        )
+        self.assertEqual(message.max_forwards, 70)
+        self.assertEqual(
+            message.to_address,
+            Address(uri=URI(scheme="sip", host="atlanta.com", user="alice")),
+        )
+        self.assertEqual(message.proxy_authenticate, None)
+        self.assertEqual(message.user_agent, "Tester/0.1.0")
+        self.assertEqual(
+            message.via,
+            [
+                Via(
+                    transport="WSS",
+                    host="mYn6S3lQaKjo.invalid",
+                    parameters=Parameters(branch="z9hG4bKgD24yaj"),
+                )
+            ],
+        )
+        self.assertEqual(message.www_authenticate, None)
+
+        self.assertEqual(str(message), message_str)
+
+    def test_response(self) -> None:
+        message_str = lf2crlf(
+            """SIP/2.0 200 OK
+Via: SIP/2.0/WSS K1IXduq1pcuX.invalid;branch=z9hG4bKAVaf5Tk;received=80.200.136.90;rport=54087
+From: <sip:alice@atlanta.com>;tag=8hZmsuF0Kb
+To: <sip:alice@atlanta.com>;tag=Bg8X3vvKyrmKH
+Call-ID: t87Br1RHAoBz2FsrKKk6hV
+CSeq: 1 REGISTER
+Date: Thu, 01 Feb 2018 11:29:53 GMT
+User-Agent: FreeSWITCH-mod_sofia/1.6.20-37-987c9b9~64bit
+Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, MESSAGE, INFO, UPDATE, REGISTER, REFER, NOTIFY, PUBLISH, SUBSCRIBE
+Supported: timer, path, replaces
+Content-Length: 0
+
+"""
+        )
+
+        message = Message.parse(message_str)
+        assert isinstance(message, Response)
+
+        self.assertEqual(message.code, 200)
+        self.assertEqual(message.phrase, "OK")
+        self.assertEqual(message.body, "")
+
+        self.assertEqual(str(message), message_str)
+
+    def test_header_authorization(self) -> None:
+        request = dummy_message()
+
+        request.authorization = AUTHORIZATION
+        self.assertEqual(request.authorization, AUTHORIZATION)
+        self.assertMessageHeaders(
+            request,
+            [
+                'Authorization: Digest username="Alice", realm="atlanta.com", '
+                'nonce="84a4cc6f3082121f32b42a2187831a9e", '
+                'response="7587245234b3434cc3412213e5f113a5432"'
+            ],
+        )
+
+        request.authorization = None
+        self.assertEqual(request.authorization, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_call_id(self) -> None:
+        request = dummy_message()
+
+        with self.assertRaises(KeyError):
+            request.call_id
+
+        request.call_id = "abc"
+        self.assertEqual(request.call_id, "abc")
+        self.assertMessageHeaders(request, ["Call-ID: abc"])
+
+    def test_header_contact(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.contact, [])
+        request.contact = [ADDRESS]
+        self.assertEqual(request.contact, [ADDRESS])
+        self.assertMessageHeaders(request, ["Contact: <sip:example.com>"])
+
+    def test_header_content_length(self) -> None:
+        request = dummy_message()
+
+        request.content_length = 10
+        self.assertEqual(request.content_length, 10)
+        self.assertMessageHeaders(request, ["Content-Length: 10"])
+
+        request.content_length = None
+        self.assertEqual(request.content_length, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_content_type(self) -> None:
+        request = dummy_message()
+
+        request.content_type = "application/sdp"
+        self.assertEqual(request.content_type, "application/sdp")
+        self.assertMessageHeaders(request, ["Content-Type: application/sdp"])
+
+        request.content_type = None
+        self.assertEqual(request.content_type, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_cseq(self) -> None:
+        request = dummy_message()
+
+        with self.assertRaises(KeyError):
+            request.cseq
+
+        request.cseq = CSEQ
+        self.assertEqual(request.cseq, CSEQ)
+        self.assertMessageHeaders(request, ["CSeq: 1 OPTIONS"])
+
+    def test_header_from_address(self) -> None:
+        request = dummy_message()
+
+        with self.assertRaises(KeyError):
+            request.from_address
+
+        request.from_address = ADDRESS
+        self.assertEqual(request.from_address, ADDRESS)
+        self.assertMessageHeaders(request, ["From: <sip:example.com>"])
+
+    def test_header_max_forwards(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.max_forwards, None)
+
+        request.max_forwards = 1
+        self.assertEqual(request.max_forwards, 1)
+        self.assertMessageHeaders(request, ["Max-Forwards: 1"])
+
+    def test_header_proxy_authenticate(self) -> None:
+        request = dummy_message()
+
+        request.proxy_authenticate = AUTHENTICATE
+        self.assertEqual(request.proxy_authenticate, AUTHENTICATE)
+        self.assertMessageHeaders(
+            request,
+            [
+                'Proxy-Authenticate: Digest realm="atlanta.com", domain="sip:boxesbybob.com", '
+                'qop="auth", nonce="f84f1cec41e6cbe5aea9c8e88d359", opaque="", stale=FALSE, '
+                "algorithm=MD5"
+            ],
+        )
+
+        request.proxy_authenticate = None
+        self.assertEqual(request.proxy_authenticate, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_proxy_authorization(self) -> None:
+        request = dummy_message()
+
+        request.proxy_authorization = AUTHORIZATION
+        self.assertEqual(request.proxy_authorization, AUTHORIZATION)
+        self.assertMessageHeaders(
+            request,
+            [
+                'Proxy-Authorization: Digest username="Alice", realm="atlanta.com", '
+                'nonce="84a4cc6f3082121f32b42a2187831a9e", '
+                'response="7587245234b3434cc3412213e5f113a5432"'
+            ],
+        )
+
+        request.proxy_authorization = None
+        self.assertEqual(request.proxy_authorization, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_record_route(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.record_route, [])
+
+        request.record_route = [ADDRESS]
+        self.assertEqual(request.record_route, [ADDRESS])
+        self.assertMessageHeaders(request, ["Record-Route: <sip:example.com>"])
+
+    def test_header_route(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.route, [])
+
+        request.route = [ADDRESS]
+        self.assertEqual(request.route, [ADDRESS])
+        self.assertMessageHeaders(request, ["Route: <sip:example.com>"])
+
+    def test_header_to_address(self) -> None:
+        request = dummy_message()
+
+        with self.assertRaises(KeyError):
+            request.to_address
+
+        request.to_address = ADDRESS
+        self.assertEqual(request.to_address, ADDRESS)
+        self.assertMessageHeaders(request, ["To: <sip:example.com>"])
+
+    def test_header_user_agent(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.user_agent, None)
+
+        request.user_agent = "Tester/0.1.0"
+        self.assertEqual(request.user_agent, "Tester/0.1.0")
+        self.assertMessageHeaders(request, ["User-Agent: Tester/0.1.0"])
+
+        request.user_agent = None
+        self.assertEqual(request.user_agent, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_header_via(self) -> None:
+        request = dummy_message()
+
+        self.assertEqual(request.via, [])
+
+        request.via = [VIA]
+        self.assertEqual(request.via, [VIA])
+        self.assertMessageHeaders(
+            request, ["Via: SIP/2.0/WSS mYn6S3lQaKjo.invalid;branch=z9hG4bKgD24yaj"]
+        )
+
+    def test_header_www_authenticate(self) -> None:
+        request = dummy_message()
+
+        request.www_authenticate = AUTHENTICATE
+        self.assertEqual(request.www_authenticate, AUTHENTICATE)
+        self.assertMessageHeaders(
+            request,
+            [
+                'WWW-Authenticate: Digest realm="atlanta.com", domain="sip:boxesbybob.com", '
+                'qop="auth", nonce="f84f1cec41e6cbe5aea9c8e88d359", opaque="", stale=FALSE, '
+                "algorithm=MD5"
+            ],
+        )
+
+        request.www_authenticate = None
+        self.assertEqual(request.www_authenticate, None)
+        self.assertMessageHeaders(request, [])
+
+    def test_too_few_lines(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            Message.parse("SIP/2.0 200 OK")
+        self.assertEqual(str(cm.exception), "SIP message has too few lines")
+
+    def test_neither_request_nor_response(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            Message.parse("SIP/3.0\r\n")
+        self.assertEqual(
+            str(cm.exception), "SIP message is neither request nor response"
+        )


### PR DESCRIPTION
The API is:

- Parsing is done using `Message.parse()` which returns either a `Request` or a `Response`.
- Serialisation is done using `str(request)` or `str(response)`.
- `Request` and `Response` internally store the headers as strings, but they expose them using typed, header-specific accessors.