### PR TITLE
Simplify Makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install packages
         run: make setup-test
       - name: Run linters
-        run: make ci-lint
+        run: make lint lint-pkg
 
   test:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
       - name: Install packages
         run: make setup-test
       - name: Run tests
-        run: make ci-test
+        run: make test
       - name: Upload coverage report
         uses: codecov/codecov-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.mo
 *.pyc
 .mypy_cache
-.*-done
+.ruff_cache
 
 # Test artifacts
 .coverage*

--- a/Makefile
+++ b/Makefile
@@ -1,100 +1,22 @@
-
-SRC_DIRS = src/
-TEST_DIRS = tests/
-PYTHON_DIRS = $(SRC_DIRS) $(TEST_DIRS)
-PYTHON_FILES = $(shell find $(PYTHON_DIRS) -name '*.py') setup.py
-
-.DEFAULT_GOAL: all
-
-all: test lint
-
-help:
-	@echo "Simply run `make` to run all linting and testing tasks."
-	@echo ""
-	@echo "You may also run `make --jobs 4 --keep-going` for a faster run."
-	@echo ""
-	@echo "Extra targets:"
-	@echo "- ci-lint / ci-test: run tasks for continuous integration"
-	@echo "- clean: Remove temporary files"
-	@echo "- lint-pkg: Check the packaging setup"
-	@echo "- setup-test: Install all development dependencies"
-
-.PHONY: all help
-
-
-# Cleanup
+all: test lint lint-pkg
 
 clean:
-	-rm .*-done
-	coverage erase
+	rm -rf .coverage .mypy_cache .ruff_cache docs/_build htmlcov
 
-.PHONY: clean
-
-# Dependencies
-
-setup-test: .pip-done
-
-
-.pip-done: setup.py pyproject.toml
-	pip install --upgrade pip setuptools wheel
-	pip install --editable .[dev]
-	@touch $@
-
-.PHONY: setup-test
-
-
-# Linting
-
-
-
-lint: .ruff-format-done .ruff-check-done
-
-ci-lint: lint lint-pkg
-
-.ruff-format-done: $(PYTHON_FILES) | .pip-done
-	ruff format --diff $+
-	@touch $@
-
-.ruff-check-done: $(PYTHON_FILES) | .pip-done
-	ruff check --diff $+
-	@touch $@
+lint:
+	ruff check --diff
+	ruff format --diff
+	mypy src tests
 
 lint-pkg:
 	check-manifest
 	pyroma --directory .
 
-.PHONY: ci-lint lint lint-pkg
+setup-test:
+	pip install --editable .[dev]
 
-
-# Tests
-
-test: test-types test-unittest
-
-ci-test: test-types xmlcov
-
-test-types: .mypy-done
-
-test-unittest: .coverage
-
-.coverage: $(PYTHON_FILES) | .pip-done
-	coverage run --module unittest discover -vv $(TEST_DIRS)
-	coverage report
-
-.mypy-done: $(PYTHON_FILES) | .pip-done
-	mypy $(PYTHON_DIRS)
-	@touch $@
-
-htmlcov: htmlcov/index.html
-
-htmlcov/index.html: .coverage
+test:
+	coverage erase
+	coverage run -m unittest discover -v
 	coverage html
-
-xmlcov: coverage.xml
-
-coverage.xml: .coverage
-	coverage xml
-
-.PHONY: htmlcov xmlcov
-
-.PHONY: ci-test test test-types test-unittest
-.PHONY: test test-types test-unittest
+	coverage report --fail-under=100

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools
-
-setuptools.setup()


### PR DESCRIPTION
The Makefile is overcomplicated, and the use of stamps makes it tedious to re-run tests.