### PR TITLE
Provide access to raw message headers

### DIFF
--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -13,3 +13,6 @@ Messages
    :members:
    :inherited-members:
    :exclude-members: parse
+
+.. autoclass:: sipmessage.Headers
+   :members:

--- a/src/sipmessage/__init__.py
+++ b/src/sipmessage/__init__.py
@@ -8,7 +8,7 @@ import importlib.metadata
 from .address import Address
 from .auth import AuthChallenge, AuthCredentials, AuthParameters
 from .cseq import CSeq
-from .message import Message, Request, Response
+from .message import Headers, Message, Request, Response
 from .parameters import Parameters
 from .uri import URI
 from .via import Via
@@ -19,6 +19,7 @@ __all__ = [
     "AuthCredentials",
     "AuthParameters",
     "CSeq",
+    "Headers",
     "Message",
     "Parameters",
     "Request",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -184,7 +184,7 @@ Content-Length: 0
     )
 
     def assertMessageHeaders(self, request: Message, values: list[str]) -> None:
-        self.assertEqual(str(request._headers).split("\r\n")[:-2], values)
+        self.assertEqual(str(request.headers).split("\r\n")[:-2], values)
 
     def _test_request(self, message_bytes: bytes) -> None:
         message = Message.parse(message_bytes)


### PR DESCRIPTION
While it is usually preferable to use the typed accessors for the individual headers, it may be necessary to manipulate the raw string values, for instance to set custom headers.