### PR TITLE
Add a `Headers.keys()` method

### DIFF
--- a/src/sipmessage/message.py
+++ b/src/sipmessage/message.py
@@ -77,6 +77,12 @@ class Headers:
                 return values
         return []
 
+    def keys(self) -> list[str]:
+        """
+        Return the names of all the headers.
+        """
+        return [k for (k, _values) in self._list]
+
     def remove(self, key: str) -> None:
         """
         Remove the given header.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -79,6 +79,7 @@ class HeadersTest(unittest.TestCase):
 
 """),
         )
+        self.assertEqual(headers.keys(), ["Via"])
 
         headers.add(
             "Via",
@@ -101,6 +102,7 @@ From: <sip:alice@atlanta.com>
 
 """),
         )
+        self.assertEqual(headers.keys(), ["Via", "From"])
 
     def test_set(self) -> None:
         headers = Headers()
@@ -112,6 +114,7 @@ From: <sip:alice@atlanta.com>
 
 """),
         )
+        self.assertEqual(headers.keys(), ["To"])
 
         headers.set("To", "Alice <sip:alice@biloxi.com>")
         self.assertEqual(
@@ -134,6 +137,7 @@ From: <sip:alice@atlanta.com>
 
 """),
         )
+        self.assertEqual(headers.keys(), ["Via"])
 
         headers.setlist(
             "Via",
@@ -149,6 +153,7 @@ Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8;received=192.0.2.1
 
 """),
         )
+        self.assertEqual(headers.keys(), ["Via"])
 
 
 class MessageTest(unittest.TestCase):


### PR DESCRIPTION
Make it possible to inspect which headers are present in a set of headers.