### PR TITLE
Fix duplicated `either` in the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ sipmessage
    :alt: Coverage
 
 The ``sipmessage`` project provides a set of Python helpers and structures
-for parsing and serialising SIP messages. It can be used to manipulate either
+for parsing and serialising SIP messages. It can be used to manipulate
 either entire :doc:`requests and responses <messages>` or individual
 :doc:`header values <headers>`.
 


### PR DESCRIPTION
This is the same typo that was fixed in
dcc8c75eaf90557a9ba76cf52185533a3794f56a for the README file.